### PR TITLE
[kubernetes] container ready, send data to remote OTEL collector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.16-alpine AS build
+WORKDIR /src
+ENV CGO_ENABLED=0
+COPY . .
+
+RUN go build -o /app/polyhedron ./server
+CMD ["/app/polyhedron"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: init
+
+# docker settings
+REGISTRY := "702835727665.dkr.ecr.us-east-1.amazonaws.com"
+SERVICE := "polyhedron"
+IMAGE := "$(REGISTRY)/$(SERVICE)"
+
+# Docker Image management
+build: 
+	docker build --pull -t $(IMAGE):latest .
+
+push: 
+	docker push $(IMAGE):latest
+
+### TESTING
+local: 
+	docker run -p 8090:8090 --rm $(IMAGE):latest
+
+bash: 
+	docker run --rm -it $(IMAGE):latest bash  

--- a/k8s/polyhedron.yaml
+++ b/k8s/polyhedron.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: polyhedron
+  labels:
+    app: polyhedron
+  namespace: basenji
+spec:
+  selector:
+    matchLabels:
+      app: polyhedron
+  template:
+    metadata:
+      labels:
+        app: polyhedron
+    spec:
+      containers:
+      - name: polyhedron
+        image: 702835727665.dkr.ecr.us-east-1.amazonaws.com/polyhedron:latest
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 100m
+            memory: 256Mi
+        env:
+        - name: HONEYCOMB_API_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: internal-bark-config
+              key: api_key
+        - name: HONEYCOMB_DATASET
+          valueFrom:
+            configMapKeyRef:
+              name: internal-bark-config
+              key: dataset_name
+        - name: OTLP_ENDPOINT
+          value: "opentelemetry-collector.basenji:4317"
+        - name: SERVICE_NAME
+          value: polyhedron
+        ports:
+        - name: otlp
+          containerPort: 4317
+          protocol: TCP
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: polyhedron
+  labels:
+    app: polyhedron
+  namespace: basenji
+spec:
+  selector:
+    app: polyhedron
+  ports:
+    - name: otlp
+      protocol: TCP
+      port: 4317
+      targetPort: 4317
+    - name: local
+      protocol: TCP
+      port: 8090
+      targetPort: 8090

--- a/server/otlp.go
+++ b/server/otlp.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
@@ -16,9 +17,13 @@ import (
 )
 
 func createOTLPExporter(ctx context.Context) (*otlp.Exporter, error) {
+	otlp_endpoint := os.Getenv("OTLP_ENDPOINT")
+	if otlp_endpoint == "" {
+		otlp_endpoint = "localhost:4317"
+	}
 	return otlp.NewExporter(ctx, otlpgrpc.NewDriver(
-		otlpgrpc.WithInsecure(),                 // insecure because sending to localhost
-		otlpgrpc.WithEndpoint("localhost:4317"), // otel-collector running as agent on this host (4317 is the default grpc port)
+		otlpgrpc.WithInsecure(),              // insecure because sending to localhost
+		otlpgrpc.WithEndpoint(otlp_endpoint), // otel-collector running as agent on this host (4317 is the default grpc port)
 		otlpgrpc.WithHeaders(map[string]string{"ContentType": "application/grpc"}),
 	))
 }


### PR DESCRIPTION
## Which problem is this PR solving?
- Support running on Kubernetes
- Allow for remote Open Telemetry Collector to be used if desired.

## Short description of the changes
- Add kubernetes manifests (deployment, service)
- Dockerize the `server` component of the application
- Makefile added to help build, test and push the container image.

This issue is related to getting metrics supported in Basenji.
https://app.asana.com/0/1200324513505271/1200883811259834

